### PR TITLE
Add system module with push_env and push_argv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# OS stuff
+.DS_Store

--- a/rmsutil/system.py
+++ b/rmsutil/system.py
@@ -2,6 +2,8 @@ import contextlib
 import os
 import sys
 
+import six
+
 
 @contextlib.contextmanager
 def push_env(**kwargs):
@@ -49,6 +51,11 @@ def push_argv(*args):
         *args: A list of strings to append to sys.argv
 
     """
+
+    # NOTE(kgriffs): argparse is OK with args of type unicode,
+    #   so push_argv isn't strict about it either.
+    if not all(isinstance(arg, six.string_types) for arg in args):
+        raise TypeError('All args must be strings')
 
     old_argv, sys.argv = sys.argv, sys.argv[:1]
     sys.argv.extend(args)

--- a/rmsutil/system.py
+++ b/rmsutil/system.py
@@ -1,0 +1,59 @@
+import contextlib
+import os
+import sys
+
+
+@contextlib.contextmanager
+def push_env(**kwargs):
+    """Temporarily modify os.environ within a given context.
+
+    Args:
+        **kwargs: An arbitrary list of names and values to set in
+            the environment. Each name and value must be a string.
+
+    """
+
+    try:
+        # NOTE(kgriffs): os.environ is actually of type os._Environ,
+        #   which is a subclass of dict. os._Environ.copy() returns
+        #   an instance of dict. We only use old_env to update (rather
+        #   than reassign) os.environ, so we don't actually need an
+        #   instance of os._Environ. If we were to try replacing
+        #   os.environ with a regular dict, os.environ and os.getenv()
+        #   would no longer stay in sync, we would lose the type
+        #   check when assigning env values, etc.
+        #
+        #   If we wanted to reassign, we could probably get away with
+        #   it by constructing old_env via os._Environ(), but that
+        #   would make us more dependent on Python internals that may
+        #   or may not change over time.
+        old_env = os.environ.copy()
+
+        for key, value in kwargs.items():
+            os.environ[key] = value
+
+        yield
+
+    finally:
+        # NOTE(kgriffs): Leave the existing instance of os.environ
+        #   in place per the note above.
+        os.environ.clear()
+        os.environ.update(old_env)
+
+
+@contextlib.contextmanager
+def push_argv(*args):
+    """Temporarily extend sys.argv with additional arguments.
+
+    Args:
+        *args: A list of strings to append to sys.argv
+
+    """
+
+    old_argv, sys.argv = sys.argv, sys.argv[:1]
+    sys.argv.extend(args)
+
+    try:
+        yield
+    finally:
+        sys.argv = old_argv

--- a/rmsutil/system.py
+++ b/rmsutil/system.py
@@ -6,8 +6,13 @@ import six
 
 
 @contextlib.contextmanager
-def push_env(**kwargs):
-    """Temporarily modify os.environ within a given context.
+def update_env(**kwargs):
+    """Temporarily modifies os.environ within a given context.
+
+    Upon entering the context, os.environ is updated with the values
+    specified. If an environment variable is already present, it will
+    be temporarily overwritten. The environment is restored once
+    execution leaves the context.
 
     Args:
         **kwargs: An arbitrary list of names and values to set in
@@ -44,11 +49,17 @@ def push_env(**kwargs):
 
 
 @contextlib.contextmanager
-def push_argv(*args):
-    """Temporarily extend sys.argv with additional arguments.
+def override_argv(*args):
+    """Temporarily overrides the contents of sys.argv.
+
+    Upon entering the context, the arguments in sys.argv are replaced
+    with those specified, except for the process name which remains
+    static. The original arguments are restored once execution leaves
+    the context.
 
     Args:
-        *args: A list of strings to append to sys.argv
+        *args: A list of strings to append to sys.argv immediately
+            following the process name.
 
     """
 
@@ -57,8 +68,7 @@ def push_argv(*args):
     if not all(isinstance(arg, six.string_types) for arg in args):
         raise TypeError('All args must be strings')
 
-    old_argv, sys.argv = sys.argv, sys.argv[:1]
-    sys.argv.extend(args)
+    old_argv, sys.argv = sys.argv, sys.argv[:1] + list(args)
 
     try:
         yield

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
     license='Apache 2.0',
     packages=find_packages(),
     install_requires=[
+        'six',
     ],
 )

--- a/test-requirements-pep8.txt
+++ b/test-requirements-pep8.txt
@@ -1,0 +1,3 @@
+flake8
+flake8-import-order
+pep8-naming

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 coverage
-flake8
 pytest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 coverage
+ipdb
 pytest

--- a/tests/system/test_push_argv.py
+++ b/tests/system/test_push_argv.py
@@ -1,0 +1,30 @@
+from __future__ import unicode_literals
+
+import sys
+
+import pytest
+
+import rmsutil.system
+
+
+def test_push_argv():
+    def assert_absent():
+        assert '--cats' not in sys.argv
+        assert '99' not in sys.argv
+
+    assert_absent()
+
+    with rmsutil.system.push_argv('--cats', '99'):
+        assert '--cats' in sys.argv
+        assert '99' in sys.argv
+
+    assert_absent()
+
+
+def test_push_argv_raised():
+    with pytest.raises(Exception):
+        with rmsutil.system.push_argv('--cats'):
+            assert '--cats' in sys.argv
+            raise Exception()
+
+    assert '--cats' not in sys.argv

--- a/tests/system/test_push_argv.py
+++ b/tests/system/test_push_argv.py
@@ -1,5 +1,4 @@
-from __future__ import unicode_literals
-
+import argparse
 import sys
 
 import pytest
@@ -14,9 +13,22 @@ def test_push_argv():
 
     assert_absent()
 
-    with rmsutil.system.push_argv('--cats', '99'):
+    # NOTE(kgriffs): argparse is OK with args of type unicode,
+    #   so push_argv isn't strict about it either.
+    with rmsutil.system.push_argv(
+        u'--cats', 'yes',
+        '--answer', u'42',
+    ):
         assert '--cats' in sys.argv
-        assert '99' in sys.argv
+        assert 'yes' in sys.argv
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--cats')
+        parser.add_argument('--answer', type=int)
+
+        args = parser.parse_args()
+        assert args.cats == 'yes'
+        assert args.answer == 42
 
     assert_absent()
 
@@ -28,3 +40,13 @@ def test_push_argv_raised():
             raise Exception()
 
     assert '--cats' not in sys.argv
+
+
+def test_push_argv_requires_string_values():
+    with pytest.raises(TypeError):
+        with rmsutil.system.push_argv(1234):
+            pass
+
+    with pytest.raises(TypeError):
+        with rmsutil.system.push_argv('-x', 1234):
+            pass

--- a/tests/system/test_push_env.py
+++ b/tests/system/test_push_env.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 
 import pytest
@@ -16,7 +14,7 @@ def test_push_env():
     assert_absent()
 
     with rmsutil.system.push_env(
-        OLIVAW_HOST='127.0.0.1',
+        OLIVAW_HOST=u'127.0.0.1',  # os._Environ allows type unicode
         OLIVAW_USERNAME='user',
         OLIVAW_PASSWORD='pwd',
     ):
@@ -55,3 +53,9 @@ def test_push_env_raises():
             raise Exception()
 
     assert 'OLIVAW_HOST' not in os.environ
+
+
+def test_push_env_requires_string_values():
+    with pytest.raises(TypeError):
+        with rmsutil.system.push_env(NAME=1234):
+            pass

--- a/tests/system/test_push_env.py
+++ b/tests/system/test_push_env.py
@@ -32,6 +32,20 @@ def test_push_env():
     assert_absent()
 
 
+def test_no_side_effects():
+    with rmsutil.system.push_env(OLIVAW_TEST_VALUE='abcd'):
+        pass
+
+    os.environ['OLIVAW_TEST_VALUE'] = '1234'
+    assert os.getenv('OLIVAW_TEST_VALUE') == '1234'
+
+    del os.environ['OLIVAW_TEST_VALUE']
+    assert os.getenv('OLIVAW_TEST_VALUE') is None
+
+    with pytest.raises(TypeError):
+        os.environ['OLIVAW_TEST_VALUE'] = 1234
+
+
 def test_push_env_raises():
     with pytest.raises(Exception):
         with rmsutil.system.push_env(

--- a/tests/system/test_push_env.py
+++ b/tests/system/test_push_env.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals
+
+import os
+
+import pytest
+
+import rmsutil.system
+
+
+def test_push_env():
+    def assert_absent():
+        assert 'OLIVAW_HOST' not in os.environ
+        assert 'OLIVAW_USERNAME' not in os.environ
+        assert 'OLIVAW_PASSWORD' not in os.environ
+
+    assert_absent()
+
+    with rmsutil.system.push_env(
+        OLIVAW_HOST='127.0.0.1',
+        OLIVAW_USERNAME='user',
+        OLIVAW_PASSWORD='pwd',
+    ):
+        assert os.environ['OLIVAW_HOST'] == '127.0.0.1'
+        assert os.environ['OLIVAW_USERNAME'] == 'user'
+        assert os.environ['OLIVAW_PASSWORD'] == 'pwd'
+
+        with rmsutil.system.push_env(OLIVAW_PASSWORD='overridden'):
+            assert os.environ['OLIVAW_PASSWORD'] == 'overridden'
+
+        assert os.environ['OLIVAW_PASSWORD'] == 'pwd'
+
+    assert_absent()
+
+
+def test_push_env_raises():
+    with pytest.raises(Exception):
+        with rmsutil.system.push_env(
+            OLIVAW_HOST='127.0.0.1',
+        ):
+            assert os.environ['OLIVAW_HOST'] == '127.0.0.1'
+            raise Exception()
+
+    assert 'OLIVAW_HOST' not in os.environ

--- a/tests/system/test_update_env.py
+++ b/tests/system/test_update_env.py
@@ -5,7 +5,7 @@ import pytest
 import rmsutil.system
 
 
-def test_push_env():
+def test_update_env():
     def assert_absent():
         assert 'OLIVAW_HOST' not in os.environ
         assert 'OLIVAW_USERNAME' not in os.environ
@@ -13,7 +13,7 @@ def test_push_env():
 
     assert_absent()
 
-    with rmsutil.system.push_env(
+    with rmsutil.system.update_env(
         OLIVAW_HOST=u'127.0.0.1',  # os._Environ allows type unicode
         OLIVAW_USERNAME='user',
         OLIVAW_PASSWORD='pwd',
@@ -22,7 +22,7 @@ def test_push_env():
         assert os.environ['OLIVAW_USERNAME'] == 'user'
         assert os.environ['OLIVAW_PASSWORD'] == 'pwd'
 
-        with rmsutil.system.push_env(OLIVAW_PASSWORD='overridden'):
+        with rmsutil.system.update_env(OLIVAW_PASSWORD='overridden'):
             assert os.environ['OLIVAW_PASSWORD'] == 'overridden'
 
         assert os.environ['OLIVAW_PASSWORD'] == 'pwd'
@@ -31,7 +31,7 @@ def test_push_env():
 
 
 def test_no_side_effects():
-    with rmsutil.system.push_env(OLIVAW_TEST_VALUE='abcd'):
+    with rmsutil.system.update_env(OLIVAW_TEST_VALUE='abcd'):
         pass
 
     os.environ['OLIVAW_TEST_VALUE'] = '1234'
@@ -44,9 +44,9 @@ def test_no_side_effects():
         os.environ['OLIVAW_TEST_VALUE'] = 1234
 
 
-def test_push_env_raises():
+def test_update_env_raises():
     with pytest.raises(Exception):
-        with rmsutil.system.push_env(
+        with rmsutil.system.update_env(
             OLIVAW_HOST='127.0.0.1',
         ):
             assert os.environ['OLIVAW_HOST'] == '127.0.0.1'
@@ -55,7 +55,7 @@ def test_push_env_raises():
     assert 'OLIVAW_HOST' not in os.environ
 
 
-def test_push_env_requires_string_values():
+def test_update_env_requires_string_values():
     with pytest.raises(TypeError):
-        with rmsutil.system.push_env(NAME=1234):
+        with rmsutil.system.update_env(NAME=1234):
             pass

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,7 @@ commands =
     coverage report
 
 [testenv:pep8]
-deps =
-    flake8
-    flake8-import-order
-    pep8-naming
+deps = -rtest-requirements-pep8.txt
 
 commands = flake8 . {posargs}
 


### PR DESCRIPTION
This patch factors out push_env and push_argv from Olivaw. These context managers are useful in testing CLI apps and also for passing options to scripts when you can't directly control the way they are subprocessed (e.g., Ansible dynamic inventory scripts).
